### PR TITLE
feat(highlight.js): add support for highlighting Elixir code

### DIFF
--- a/app/javascript/highlight.js
+++ b/app/javascript/highlight.js
@@ -3,6 +3,7 @@ import hljs from "highlight.js"
 const languages = [
   'ruby',
   'erb',
+  'elixir',
   'bash',
   'yaml',
   'json',


### PR DESCRIPTION
The `highlight.js` module now includes support for highlighting Elixir code. This allows the syntax highlighting library to properly highlight Elixir code blocks in our application.